### PR TITLE
upgrade jsdom and allow load scripts asynchronously

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,30 @@
+
+
+
+// We can replicate script.onload behavior using the approach below
+//    but apparently this is no longer needed since jsdom version upgrade?
+//
+// function mockDomNodeInserted (win) {
+//     var nodeImpl = require('jsdom/lib/jsdom/living/nodes/Node-impl.js').implementation.prototype;
+//     var oldInsertBefore = nodeImpl.insertBefore;
+//     var NODE_COUNT = 0;
+//
+//     var newInsertBefore = function (newElement, refElement) {
+//         NODE_COUNT++;
+//         var nodeId = 'INSERTED' + NODE_COUNT;
+//
+//         if (typeof newElement.onload === 'function') {
+//             win.document.addEventListener('DOMNodeInserted', function (ev) {
+//                 if (ev.detail.id === nodeId) {
+//                     newElement.onload.call(newElement);
+//                 }
+//             });
+//         }
+//
+//         var event = new CustomEvent('DOMNodeInserted', { detail: { id: nodeId, type: newElement.nodeName.toLowerCase() } });
+//         win.document.dispatchEvent(event);
+//         oldInsertBefore.apply(this, arguments);
+//     };
+//
+//     nodeImpl.insertBefore = newInsertBefore;
+// }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/seebigs/node-as-browser/issues"
   },
   "dependencies": {
-    "jsdom": "^9.9.1",
+    "jsdom": "^11.1.0",
     "node-fetch": "^1.6.3",
     "usertiming": "^0.1.8"
   },

--- a/test/automated.js
+++ b/test/automated.js
@@ -3,11 +3,9 @@
  */
 
 var FeatherTestBrowser = require('feather-test-browser');
-var nodeAsBrowser = require('../index.js');
+global.nodeAsBrowser = require('../index.js');
 
-global.url = 'https://www.example.com:8888/page.html?one=1&two=2#anchor';
 nodeAsBrowser.init({
-    url: url,
     html: '<!DOCTYPE html><head></head><body data-action="bhave" style="color:red"><div id="gremlins"><div class="gizmo mogwai"></div><div class="stripe mogwai"></div></div></body></html>'
 });
 

--- a/test/fixture/script.js
+++ b/test/fixture/script.js
@@ -1,0 +1,1 @@
+document.body.innerHTML += '<span>LOADED</span>';

--- a/test/specs/document.spec.js
+++ b/test/specs/document.spec.js
@@ -51,15 +51,13 @@ describe('document.body.style', function (expect) {
     expect(document.body.style.color).toBe('red');
 });
 
-describe('document.addEventListener.DOMNodeInserted', function (expect, done) {
-    spy.on(document, 'addEventListener', document.addEventListener);
-
-    document.addEventListener('DOMNodeInserted', function () {
-        // kind of a silly unit test... "if you are here, it worked"
-        expect(document.addEventListener).toHaveBeenCalled();
+describe('document.appendChild script execution and onload', function (expect, done) {
+    var s = document.createElement('script');
+    s.src = __dirname + '/../fixture/script.js';
+    s.onload = function () {
+        expect(this.nodeName).toBe('SCRIPT');
+        expect(document.body.innerHTML.indexOf('<span>LOADED</span>')).not.toBe(-1);
         done();
-    });
-
-    var node = document.createElement('div');
-    document.body.appendChild(node);
+    };
+    document.head.appendChild(s);
 });

--- a/test/specs/window.spec.js
+++ b/test/specs/window.spec.js
@@ -1,16 +1,6 @@
 
-describe('location', function (expect) {
-    expect(location.href).toBe(url);
-    expect(location.protocol).toBe('https:');
-    expect(location.hostname).toBe('www.example.com');
-    expect(location.port).toBe('8888');
-    expect(location.pathname).toBe('/page.html');
-    expect(location.search).toBe('?one=1&two=2');
-    expect(location.hash).toBe('#anchor');
-});
-
 describe('navigator', function (expect) {
-    expect(navigator.userAgent).toContain('Node.js');
+    expect(navigator.userAgent).toContain(' jsdom/');
 });
 
 describe('HTMLElement', function (expect) {
@@ -62,8 +52,12 @@ describe('Promise', function (expect) {
     expect(typeof Promise).toBe('function');
 });
 
+describe('Image', function (expect) {
+    expect(typeof Image).toBe('function');
+});
+
 describe('screen', function (expect) {
-    expect(typeof screen.colorDepth).toBe('number');
+    expect(typeof screen.colorDepth).toBe('number', 'screen.colorDepth');
 });
 
 describe('performance', function (expect) {
@@ -73,4 +67,17 @@ describe('performance', function (expect) {
     expect(typeof performance.measure).toBe('function', 'measure');
     expect(typeof performance.now).toBe('function', 'now');
     expect(typeof performance.navigation).toBe('object', 'navigation');
+});
+
+describe('location', function (expect) {
+    var url = 'https://www.example.com:8888/page.html?one=1&two=2#anchor';
+    nodeAsBrowser.reconfigure({ url: url });
+    expect(location.href).toBe(url);
+    expect(location.protocol).toBe('https:');
+    expect(location.hostname).toBe('www.example.com');
+    expect(location.port).toBe('8888');
+    expect(location.pathname).toBe('/page.html');
+    expect(location.search).toBe('?one=1&two=2');
+    expect(location.hash).toBe('#anchor');
+    nodeAsBrowser.reconfigure({ url: 'about:blank' });
 });


### PR DESCRIPTION
Upgrading to newest jsdom (v11) gives us onload callbacks for script loads -- if you run jsdom in "dangerous" mode :-)

So no need for crazy hacks on our side (yet)